### PR TITLE
Improve ob-release usability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM qcastel/maven-git-gpg:latest
 
-COPY ./src /ob-release
+COPY ./src/release.sh /usr/local/bin
+COPY ./src/settings.xml /usr/share/maven/conf


### PR DESCRIPTION
Move settings.xml to default settings.xml to it doesn't need to be
specified.

Move release.sh to directory on PATH for easy running.